### PR TITLE
feat(arcade): add recent squirrels filter

### DIFF
--- a/arcade/README.md
+++ b/arcade/README.md
@@ -9,12 +9,12 @@ This directory contains data expressions that drive the Squirrel Morph Sightings
 - [Latest squirrel style expression](./latest-squirrel-style-expression.js)
 - [Squirrels with photos style expression](./squirrels-with-photos-style-expression.js)
 
-
 ### [Dashboard](https://www.arcgis.com/apps/dashboards/21159e6135bc40158c4314782fc20f5c)
 
 - [Black squirrels indicator](./black-squirrels-indicator.js)
 - [White squirrels indicator](./white-squirrels-indicator.js)
 - [Collection days indicator](./collection-days-indicator.js)
+- [Recent squirrels filter](./recent-squirrels-filter.js)
 - [Recent squirrels table](./recent-squirrels-table.js)
 - [Squirrels with photos table](./squirrels-with-photos-table.js)
 - [Collection days and observations serial chart](./collection-days-and-observations-serial-chart-data-expression.js)

--- a/arcade/recent-squirrels-filter.js
+++ b/arcade/recent-squirrels-filter.js
@@ -1,0 +1,52 @@
+// Get squirrel data
+var fs = FeatureSetByPortalItem(
+    Portal('https://www.arcgis.com/'),
+    'e714bfeed51f447b8a36051dd62c0666',
+    0,
+    ["*"],
+    true
+);
+
+// Today's date
+var dateToday = DateOnly(Today())
+
+// Create empty arrays for filtered features
+var featuresToday = []
+var featuresLastSevenDays = []
+var newFeatures = []
+
+// Define the schema for the new FeatureSet
+var fields = Schema(First(fs)).fields
+var newFields = []
+for (var field of fields) {    
+    Push(newFields, { name: field.name, type: field.type})
+}
+
+// Loop through each feature in the input FeatureSet
+// to get rows with today's date and last 7 days
+for (var f in fs) {
+    // Check if the feature's date is today
+    if (DateDiff(dateToday, DateOnly(f.Date_Time), 'days') == 0) {
+        Push(featuresToday, f)
+    } else if (DateDiff(dateToday, DateOnly(f.Date_Time), 'days') <= 7) {
+        // Check if the feature's date falls in the last 7 days        
+        Push(featuresLastSevenDays, f)        
+    }
+}
+
+// Determine which arrays to iterate
+var featuresToShow = IIF(Count(featuresToday) > 0, featuresToday, featuresLastSevenDays)
+for (var feat of featuresToShow) {
+    Push(newFeatures, feat)
+}
+
+// Build json
+var jsonDict = {
+    fields: newFields,
+    spatialReference: { wkid: 102100 },
+    geometryType: "esriGeometryPoint",
+    features: newFeatures
+}
+
+// Return the new FeatureSet
+return FeatureSet(Text(jsonDict))


### PR DESCRIPTION
Adds new Arcade expression used to display either the current day's list 'o squirrels in the "Recent squirrel observations" table, or if no data exists for the current day gets the list from the last 7 days.